### PR TITLE
Create Kubernetes deployment and service

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: uptime-server-deployment
+  labels:
+    app: uptime-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: uptime-server
+  template:
+    metadata:
+      labels:
+        app: uptime-server
+    spec:
+      containers:
+      - name: uptime-server
+        image: ghcr.io/karlcaga/uptime-server:main
+        ports:
+        - containerPort: 8080

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: uptime-server
+  labels:
+    run: uptime-server
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: uptime-server


### PR DESCRIPTION
Using templates found on official k8s documentation, we created the deployment and associated service for `uptime-server`. We are using the deployment name `uptime-server` and associating the deployment with a service for discovery purposes.